### PR TITLE
feat: Add All Articles link for admin users on homepage

### DIFF
--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -42,11 +42,18 @@ export default function HomePage() {
             </div>
             
             {isAuthenticated && (
-              <Link href="/collections">
-                <Button variant="outline">
-                  Manage Collections
-                </Button>
-              </Link>
+              <div className="flex gap-3">
+                <Link href="/articles">
+                  <Button variant="outline">
+                    All Articles
+                  </Button>
+                </Link>
+                <Link href="/collections">
+                  <Button variant="outline">
+                    Manage Collections
+                  </Button>
+                </Link>
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
Add All Articles navigation button alongside Manage Collections button when user is authenticated as admin. Improves admin workflow by providing direct access to article management from the main page.

🤖 Generated with [Claude Code](https://claude.ai/code)